### PR TITLE
이슈 타입을 추가한 템플릿

### DIFF
--- a/backend/election/.github/ISSUE_TEMPLATE/config.yaml
+++ b/backend/election/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,15 @@
+blank_issues_enabled: false
+contact_links: []
+issue_types:
+  - name: Bug
+    description: An unexpected problem or behavior
+    labels: ["bug"]
+  - name: Feature
+    description: A request, idea, or new functionality
+    labels: ["enhancement"]
+  - name: Task
+    description: A specific piece of work
+    labels: ["task"]
+  - name: Story
+    description: A user story that describes a feature from the user's perspective
+    labels: ["story"]


### PR DESCRIPTION
- Project 기능 사용을 위해 Story 타입의 티켓 발급이 필요합니다. 하지만 기본 기능에는 이 타입이 없으므로 추가합니다.