### PR TITLE
[KE-21] jira 링크 연동 테스트를 위한 빈커밋

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,3 +1,4 @@
+
 blank_issues_enabled: false
 contact_links: []
 issue_types:


### PR DESCRIPTION
## 🔍 PR의 이유
- vercel 배포시 jira 이슈로 커밋이 안되는 부분이 브랜치명으로 추정되므로 원인이 맞는지 확인하기 위함

## ✨ 주요 변경사항
- [x] 없음

## 📎 참고(선택)
- 
